### PR TITLE
Remove Int NSTimeInterval helpers

### DIFF
--- a/Src/SwiftyTimer.swift
+++ b/Src/SwiftyTimer.swift
@@ -76,15 +76,6 @@ extension NSTimer {
     }
 }
 
-extension Int {
-    public var second:  NSTimeInterval { return NSTimeInterval(self) }
-    public var seconds: NSTimeInterval { return NSTimeInterval(self) }
-    public var minute:  NSTimeInterval { return NSTimeInterval(self * 60) }
-    public var minutes: NSTimeInterval { return NSTimeInterval(self * 60) }
-    public var hour:    NSTimeInterval { return NSTimeInterval(self * 3600) }
-    public var hours:   NSTimeInterval { return NSTimeInterval(self * 3600) }
-}
-
 extension Double {
     public var second:  NSTimeInterval { return self }
     public var seconds: NSTimeInterval { return self }


### PR DESCRIPTION
Double is IntegerLiteralConvertible, so 1.second, etc., still works without the Int extension.