### PR TITLE
Add `start` and `stop` instance methods to NSTimer

### DIFF
--- a/Src/SwiftyTimer.swift
+++ b/Src/SwiftyTimer.swift
@@ -75,16 +75,19 @@ extension NSTimer {
         return timer
     }
     
-    /// Schedule this timer on the specified run loop (defaults to the current run loop)
+    /// Schedule this timer on the run loop
+    ///
+    /// By default, the timer is scheduled on the current run loop for the default mode.
+    /// Specify `runLoop` or `mode` to override these defaults.
     
-    public func start(onRunLoop runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), forMode mode: String = NSDefaultRunLoopMode) {
+    public func start(runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), mode: String = NSDefaultRunLoopMode) {
         runLoop.addTimer(self, forMode: mode)
     }
     
-    /// Invalidate this timer (provided to match `start`)
+    /// Invalidate this timer (alias to `invalidate`)
     
     public func stop() {
-        self.invalidate()
+        invalidate()
     }
 }
 

--- a/Src/SwiftyTimer.swift
+++ b/Src/SwiftyTimer.swift
@@ -78,16 +78,12 @@ extension NSTimer {
     /// Schedule this timer on the run loop
     ///
     /// By default, the timer is scheduled on the current run loop for the default mode.
-    /// Specify `runLoop` or `mode` to override these defaults.
+    /// Specify `runLoop` or `modes` to override these defaults.
     
-    public func start(runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), mode: String = NSDefaultRunLoopMode) {
-        runLoop.addTimer(self, forMode: mode)
-    }
-    
-    /// Invalidate this timer (alias to `invalidate`)
-    
-    public func stop() {
-        invalidate()
+    public func start(runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), modes: [String] = [NSDefaultRunLoopMode]) {
+        for mode in modes {
+            runLoop.addTimer(self, forMode: mode)
+        }
     }
 }
 

--- a/Src/SwiftyTimer.swift
+++ b/Src/SwiftyTimer.swift
@@ -80,7 +80,9 @@ extension NSTimer {
     /// By default, the timer is scheduled on the current run loop for the default mode.
     /// Specify `runLoop` or `modes` to override these defaults.
     
-    public func start(runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), modes: [String] = [NSDefaultRunLoopMode]) {
+    public func start(runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), modes: String...) {
+        let modes = modes.count != 0 ? modes : [NSDefaultRunLoopMode]
+        
         for mode in modes {
             runLoop.addTimer(self, forMode: mode)
         }

--- a/SwiftyTimer.podspec
+++ b/SwiftyTimer.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name = 'SwiftyTimer'
+  s.version = '1.0.0'
+  s.license = 'MIT'
+  s.summary = 'Swifty API for NSTimer'
+  s.homepage = 'https://github.com/radex/SwiftyTimer'
+  s.authors = { 'Radek Pietruszewski' => 'this.is@radex.io' }
+  s.source = { :git => 'https://github.com/radex/SwiftyTimer.git', :tag => '1.0.0' }
+  
+  s.requires_arc = true
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+
+  s.source_files = 'Src/*.swift'
+end

--- a/Tests/SwiftyTimerTests/main.swift
+++ b/Tests/SwiftyTimerTests/main.swift
@@ -62,7 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 fired = true
             }
         }
-        timer4.start()
+        timer4.start(runLoop: NSRunLoop.currentRunLoop(), modes: NSDefaultRunLoopMode)
     }
 
     func test6() {

--- a/Tests/SwiftyTimerTests/main.swift
+++ b/Tests/SwiftyTimerTests/main.swift
@@ -56,7 +56,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var fired = false
         timer4 = NSTimer.new(every: 0.1.seconds) {
             if fired {
-                self.timer4.stop()
+                self.timer4.invalidate()
                 self.test6()
             } else {
                 fired = true


### PR DESCRIPTION
`start` is a convenience method to schedule an NSTimer on a NSRunLoop.
`stop` simply calls `invalidate` and is provided to mirror `start`.