### PR TITLE
Use Void return type instead of ().

### DIFF
--- a/Src/SwiftyTimer.swift
+++ b/Src/SwiftyTimer.swift
@@ -25,9 +25,9 @@
 import Foundation
 
 private class NSTimerActor {
-    var block: () -> ()
+    var block: () -> Void
     
-    init(_ block: () -> ()) {
+    init(_ block: () -> Void ) {
         self.block = block
     }
     
@@ -44,7 +44,7 @@ extension NSTimer {
     /// **Note:** the timer won't fire until it's scheduled on the run loop.
     /// Use `NSTimer.after` to create and schedule a timer in one step.
     
-    public class func new(after interval: NSTimeInterval, _ block: () -> ()) -> NSTimer {
+    public class func new(after interval: NSTimeInterval, _ block: () -> Void ) -> NSTimer {
         let actor = NSTimerActor(block)
         return self.init(timeInterval: interval, target: actor, selector: "fire", userInfo: nil, repeats: false)
     }
@@ -54,14 +54,14 @@ extension NSTimer {
     /// **Note:** the timer won't fire until it's scheduled on the run loop.
     /// Use `NSTimer.every` to create and schedule a timer in one step.
     
-    public class func new(every interval: NSTimeInterval, _ block: () -> ()) -> NSTimer {
+    public class func new(every interval: NSTimeInterval, _ block: () -> Void ) -> NSTimer {
         let actor = NSTimerActor(block)
         return self.init(timeInterval: interval, target: actor, selector: "fire", userInfo: nil, repeats: true)
     }
     
     /// Create and schedule a timer that will call `block` once after the specified time.
     
-    public class func after(interval: NSTimeInterval, _ block: () -> ()) -> NSTimer {
+    public class func after(interval: NSTimeInterval, _ block: () -> Void ) -> NSTimer {
         let timer = NSTimer.new(after: interval, block)
         timer.start()
         return timer
@@ -69,7 +69,7 @@ extension NSTimer {
     
     /// Create and schedule a timer that will call `block` repeatedly in specified time intervals.
     
-    public class func every(interval: NSTimeInterval, _ block: () -> ()) -> NSTimer {
+    public class func every(interval: NSTimeInterval, _ block: () -> Void ) -> NSTimer {
         let timer = NSTimer.new(every: interval, block)
         timer.start()
         return timer


### PR DESCRIPTION
Apple and the community are trying to standardize on this convention.
http://ericasadun.com/2015/05/11/swift-vs-void/
https://devforums.apple.com/message/1133616