### PR TITLE
Add NSTimer to the closure parameters.

### DIFF
--- a/Src/SwiftyTimer.swift
+++ b/Src/SwiftyTimer.swift
@@ -25,14 +25,14 @@
 import Foundation
 
 private class NSTimerActor {
-    var block: () -> Void
+    var block: (timer: NSTimer) -> Void
     
-    init(_ block: () -> Void) {
+    init(_ block: (timer: NSTimer) -> Void) {
         self.block = block
     }
     
-    @objc func fire() {
-        block()
+    @objc func fire(timer: NSTimer) {
+        block(timer: timer)
     }
 }
 
@@ -44,9 +44,9 @@ extension NSTimer {
     /// **Note:** the timer won't fire until it's scheduled on the run loop.
     /// Use `NSTimer.after` to create and schedule a timer in one step.
     
-    public class func new(after interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
+    public class func new(after interval: NSTimeInterval, _ block: (timer: NSTimer) -> Void) -> NSTimer {
         let actor = NSTimerActor(block)
-        return self.init(timeInterval: interval, target: actor, selector: "fire", userInfo: nil, repeats: false)
+        return self.init(timeInterval: interval, target: actor, selector: "fire:", userInfo: nil, repeats: false)
     }
     
     /// Create a timer that will call `block` repeatedly in specified time intervals.
@@ -54,14 +54,14 @@ extension NSTimer {
     /// **Note:** the timer won't fire until it's scheduled on the run loop.
     /// Use `NSTimer.every` to create and schedule a timer in one step.
     
-    public class func new(every interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
+    public class func new(every interval: NSTimeInterval, _ block: (timer: NSTimer) -> Void) -> NSTimer {
         let actor = NSTimerActor(block)
-        return self.init(timeInterval: interval, target: actor, selector: "fire", userInfo: nil, repeats: true)
+        return self.init(timeInterval: interval, target: actor, selector: "fire:", userInfo: nil, repeats: true)
     }
     
     /// Create and schedule a timer that will call `block` once after the specified time.
     
-    public class func after(interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
+    public class func after(interval: NSTimeInterval, _ block: (timer: NSTimer) -> Void) -> NSTimer {
         let timer = NSTimer.new(after: interval, block)
         timer.start()
         return timer
@@ -69,7 +69,7 @@ extension NSTimer {
     
     /// Create and schedule a timer that will call `block` repeatedly in specified time intervals.
     
-    public class func every(interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
+    public class func every(interval: NSTimeInterval, _ block: (timer: NSTimer) -> Void) -> NSTimer {
         let timer = NSTimer.new(every: interval, block)
         timer.start()
         return timer

--- a/Tests/SwiftyTimerTests.xcodeproj/project.pbxproj
+++ b/Tests/SwiftyTimerTests.xcodeproj/project.pbxproj
@@ -89,7 +89,9 @@
 		6EE9C14B1B00BB5B00D6B91C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0640;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				TargetAttributes = {
 					6EE9C1521B00BB5B00D6B91C = {
 						CreatedOnToolsVersion = 6.4;
@@ -158,6 +160,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -224,6 +227,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = SwiftyTimerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "radex.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -235,6 +239,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = SwiftyTimerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "radex.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Tests/SwiftyTimerTests/Info.plist
+++ b/Tests/SwiftyTimerTests/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>radex.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Tests/SwiftyTimerTests/main.swift
+++ b/Tests/SwiftyTimerTests/main.swift
@@ -19,7 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func test2() {
         var fired = false
-        NSTimer.after(0.1.seconds) {
+        NSTimer.after(0.1.seconds) { timer in
             assert(!fired)
             fired = true
             self.test3()
@@ -30,7 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func test3() {
         var fired = false
-        timer1 = NSTimer.every(0.1.seconds) {
+        timer1 = NSTimer.every(0.1.seconds) { timer in
             if fired {
                 self.test4()
                 self.timer1.invalidate()
@@ -40,11 +40,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
-    let timer2 = NSTimer.new(after: 0.1.seconds) { fatalError() }
-    let timer3 = NSTimer.new(every: 0.1.seconds) { fatalError() }
+    let timer2 = NSTimer.new(after: 0.1.seconds) { timer in
+        fatalError()
+    }
+    let timer3 = NSTimer.new(every: 0.1.seconds) { timer in
+        fatalError()
+    }
     
     func test4() {
-        let timer = NSTimer.new(after: 0.1.seconds) {
+        let timer = NSTimer.new(after: 0.1.seconds) { timer in
             self.test5()
         }
         NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
@@ -54,7 +58,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func test5() {
         var fired = false
-        timer4 = NSTimer.new(every: 0.1.seconds) {
+        timer4 = NSTimer.new(every: 0.1.seconds) { timer in
             if fired {
                 self.timer4.invalidate()
                 self.test6()
@@ -66,21 +70,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func test6() {
-        let timer = NSTimer.new(after: 0.1.seconds) {
+        let timer = NSTimer.new(after: 0.1.seconds) { timer in
             self.test7()
         }
         
-        timer.start(modes: NSDefaultRunLoopMode, NSEventTrackingRunLoopMode, runLoop: NSRunLoop.currentRunLoop())
+        timer.start(NSRunLoop.currentRunLoop(), modes: NSDefaultRunLoopMode, NSEventTrackingRunLoopMode)
+    }
+    
+    func test7() {
+        NSTimer.after(0.1.seconds) { timer in
+            timer.invalidate()
+            self.test8()
+        }
     }
 
-    func test7() {
+    func test8() {
         NSTimer.after(0.1.seconds, done)
     }
     
-    func done() {
-        println("All tests passed")
+    func done(timer: NSTimer) {
+        print("All tests passed")
         app.terminate(self)
     }
+    
 }
 
 let delegate = AppDelegate()


### PR DESCRIPTION
Adding NSTimer to the closure's parameters allows the invalidation of the timer without needing to hold a reference to it (the timer) in the enclosing class. NSTimer holds a strong reference to the NSTimerActor, which in turn holds a string reference to the closure. Using a [weak self] reference in the closure alongside the NSTimer parameter will help ensure that objects can be deallocated properly.