### PR TITLE
Convert code base to swift 3.0 (Xcode 8.0 beta 2)

### DIFF
--- a/Sources/SwiftyTimer.swift
+++ b/Sources/SwiftyTimer.swift
@@ -24,22 +24,22 @@
 
 import Foundation
 
-extension NSTimer {
+extension Timer {
     
 // MARK: Schedule timers
     
     /// Create and schedule a timer that will call `block` once after the specified time.
     
-    public class func after(interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
-        let timer = NSTimer.new(after: interval, block)
+    public class func after(_ interval: TimeInterval, _ block: () -> Void) -> Timer {
+        let timer = Timer.new(after: interval, block)
         timer.start()
         return timer
     }
     
     /// Create and schedule a timer that will call `block` repeatedly in specified time intervals.
     
-    public class func every(interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
-        let timer = NSTimer.new(every: interval, block)
+    public class func every(_ interval: TimeInterval, _ block: () -> Void) -> Timer {
+        let timer = Timer.new(every: interval, block)
         timer.start()
         return timer
     }
@@ -47,8 +47,8 @@ extension NSTimer {
     /// Create and schedule a timer that will call `block` repeatedly in specified time intervals.
     /// (This variant also passes the timer instance to the block)
     
-    @nonobjc public class func every(interval: NSTimeInterval, _ block: NSTimer -> Void) -> NSTimer {
-        let timer = NSTimer.new(every: interval, block)
+    @nonobjc public class func every(_ interval: TimeInterval, _ block: (Timer) -> Void) -> Timer {
+        let timer = Timer.new(every: interval, block)
         timer.start()
         return timer
     }
@@ -61,7 +61,7 @@ extension NSTimer {
     ///         Use `NSTimer.after` to create and schedule a timer in one step.
     /// - Note: The `new` class function is a workaround for a crashing bug when using convenience initializers (rdar://18720947)
 
-    public class func new(after interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
+    public class func new(after interval: TimeInterval, _ block: () -> Void) -> Timer {
         return CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + interval, 0, 0, 0) { _ in
             block()
         }
@@ -73,7 +73,7 @@ extension NSTimer {
     ///         Use `NSTimer.every` to create and schedule a timer in one step.
     /// - Note: The `new` class function is a workaround for a crashing bug when using convenience initializers (rdar://18720947)
 
-    public class func new(every interval: NSTimeInterval, _ block: () -> Void) -> NSTimer {
+    public class func new(every interval: TimeInterval, _ block: () -> Void) -> Timer {
         return CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + interval, interval, 0, 0) { _ in
             block()
         }
@@ -86,8 +86,8 @@ extension NSTimer {
     ///         Use `NSTimer.every` to create and schedule a timer in one step.
     /// - Note: The `new` class function is a workaround for a crashing bug when using convenience initializers (rdar://18720947)
     
-    @nonobjc public class func new(every interval: NSTimeInterval, _ block: NSTimer -> Void) -> NSTimer {
-        var timer: NSTimer!
+    @nonobjc public class func new(every interval: TimeInterval, _ block: (Timer) -> Void) -> Timer {
+        var timer: Timer!
         timer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + interval, interval, 0, 0) { _ in
             block(timer)
         }
@@ -101,11 +101,11 @@ extension NSTimer {
     /// By default, the timer is scheduled on the current run loop for the default mode.
     /// Specify `runLoop` or `modes` to override these defaults.
     
-    public func start(runLoop runLoop: NSRunLoop = NSRunLoop.currentRunLoop(), modes: String...) {
-        let modes = modes.isEmpty ? [NSDefaultRunLoopMode] : modes
+    public func start(runLoop: RunLoop = RunLoop.current, modes: RunLoopMode...) {
+        let modes = modes.isEmpty ? [RunLoopMode.defaultRunLoopMode] : modes
         
         for mode in modes {
-            runLoop.addTimer(self, forMode: mode)
+            runLoop.add(self, forMode: mode)
         }
     }
 }
@@ -113,19 +113,19 @@ extension NSTimer {
 // MARK: - Time extensions
 
 extension Double {
-    public var millisecond: NSTimeInterval  { return self / 1000 }
-    public var milliseconds: NSTimeInterval { return self / 1000 }
-    public var ms: NSTimeInterval           { return self / 1000 }
+    public var millisecond: TimeInterval  { return self / 1000 }
+    public var milliseconds: TimeInterval { return self / 1000 }
+    public var ms: TimeInterval           { return self / 1000 }
     
-    public var second: NSTimeInterval       { return self }
-    public var seconds: NSTimeInterval      { return self }
+    public var second: TimeInterval       { return self }
+    public var seconds: TimeInterval      { return self }
     
-    public var minute: NSTimeInterval       { return self * 60 }
-    public var minutes: NSTimeInterval      { return self * 60 }
+    public var minute: TimeInterval       { return self * 60 }
+    public var minutes: TimeInterval      { return self * 60 }
     
-    public var hour: NSTimeInterval         { return self * 3600 }
-    public var hours: NSTimeInterval        { return self * 3600 }
+    public var hour: TimeInterval         { return self * 3600 }
+    public var hours: TimeInterval        { return self * 3600 }
     
-    public var day: NSTimeInterval          { return self * 3600 * 24 }
-    public var days: NSTimeInterval         { return self * 3600 * 24 }
+    public var day: TimeInterval          { return self * 3600 * 24 }
+    public var days: TimeInterval         { return self * 3600 * 24 }
 }

--- a/SwiftyTimer.xcodeproj/project.pbxproj
+++ b/SwiftyTimer.xcodeproj/project.pbxproj
@@ -205,11 +205,12 @@
 		3E721AB21BF7255C008AF027 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Radosław Pietruszewski";
 				TargetAttributes = {
 					3E721ABA1BF7255D008AF027 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					6E7E40891C84B1A20030CEBB = {
 						CreatedOnToolsVersion = 7.2;
@@ -417,6 +418,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -436,6 +438,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.radex.SwiftyTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -480,6 +484,7 @@
 				PRODUCT_NAME = SwiftyTimer;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -518,6 +523,7 @@
 				PRODUCT_NAME = SwiftyTimer;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -558,6 +564,7 @@
 				PRODUCT_NAME = SwiftyTimer;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};

--- a/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer OS X.xcscheme
+++ b/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer OS X.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,8 +11,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6E7E40891C84B1A20030CEBB"

--- a/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer tvOS.xcscheme
+++ b/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,8 +11,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6E7E40991C84B3790030CEBB"

--- a/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer watchOS.xcscheme
+++ b/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,8 +11,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6E7E40A71C84B4240030CEBB"

--- a/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer.xcscheme
+++ b/SwiftyTimer.xcodeproj/xcshareddata/xcschemes/SwiftyTimer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftyTimerTests/SwiftyTimerTests.xcodeproj/project.pbxproj
+++ b/SwiftyTimerTests/SwiftyTimerTests.xcodeproj/project.pbxproj
@@ -90,10 +90,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0800;
 				TargetAttributes = {
 					6EE9C1521B00BB5B00D6B91C = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -159,6 +160,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -225,7 +227,9 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = SwiftyTimerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "radex.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -236,7 +240,10 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = SwiftyTimerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "radex.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SwiftyTimerTests/SwiftyTimerTests.xcodeproj/xcshareddata/xcschemes/SwiftyTimerTests.xcscheme
+++ b/SwiftyTimerTests/SwiftyTimerTests.xcodeproj/xcshareddata/xcschemes/SwiftyTimerTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -11,8 +11,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6EE9C1521B00BB5B00D6B91C"
@@ -26,8 +25,7 @@
             buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6EE9C1621B00BB5B00D6B91C"

--- a/SwiftyTimerTests/SwiftyTimerTests/Info.plist
+++ b/SwiftyTimerTests/SwiftyTimerTests/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>radex.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftyTimerTests/SwiftyTimerTests/main.swift
+++ b/SwiftyTimerTests/SwiftyTimerTests/main.swift
@@ -1,9 +1,9 @@
 import Cocoa
 
-let app = NSApplication.sharedApplication()
+let app = NSApplication.shared()
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         test()
     }
     
@@ -23,18 +23,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func test2() {
         var fired = false
-        NSTimer.after(0.1.seconds) {
+        Timer.after(0.1.seconds) {
             assert(!fired)
             fired = true
             self.test3()
         }
     }
     
-    var timer1: NSTimer!
+    var timer1: Timer!
     
     func test3() {
         var fired = false
-        timer1 = NSTimer.every(0.1.seconds) {
+        timer1 = Timer.every(0.1.seconds) {
             if fired {
                 self.test4()
                 self.timer1.invalidate()
@@ -44,21 +44,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
-    let timer2 = NSTimer.new(after: 0.1.seconds) { fatalError() }
-    let timer3 = NSTimer.new(every: 0.1.seconds) { fatalError() }
+    let timer2 = Timer.new(after: 0.1.seconds) { fatalError() }
+    let timer3 = Timer.new(every: 0.1.seconds) { fatalError() }
     
     func test4() {
-        let timer = NSTimer.new(after: 0.1.seconds) {
+        let timer = Timer.new(after: 0.1.seconds) {
             self.test5()
         }
-        NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSDefaultRunLoopMode)
+        RunLoop.current.add(timer, forMode: RunLoopMode.defaultRunLoopMode)
     }
     
-    var timer4: NSTimer!
+    var timer4: Timer!
     
     func test5() {
         var fired = false
-        timer4 = NSTimer.new(every: 0.1.seconds) {
+        timer4 = Timer.new(every: 0.1.seconds) {
             if fired {
                 self.timer4.invalidate()
                 self.test6()
@@ -70,20 +70,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func test6() {
-        let timer = NSTimer.new(after: 0.1.seconds) {
+        let timer = Timer.new(after: 0.1.seconds) {
             self.test7()
         }
         
-        timer.start(runLoop: NSRunLoop.currentRunLoop(), modes: NSDefaultRunLoopMode, NSEventTrackingRunLoopMode)
+        timer.start(runLoop: RunLoop.current, modes: RunLoopMode.defaultRunLoopMode, RunLoopMode(NSEventTrackingRunLoopMode))
     }
 
     func test7() {
-        NSTimer.after(0.1.seconds, test8)
+        Timer.after(0.1.seconds, test8)
     }
     
     func test8() {
         var fires = 0
-        let timer = NSTimer.new(every: 0.1.seconds) { (timer: NSTimer) in
+        let timer = Timer.new(every: 0.1.seconds) { (timer: Timer) in
             guard fires <= 1 else { fatalError("should be invalidated") }
             defer { fires += 1 }
             
@@ -97,7 +97,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func test9() {
         var fires = 0
-        NSTimer.every(0.1.seconds) { (timer: NSTimer) in
+        Timer.every(0.1.seconds) { (timer: Timer) in
             guard fires <= 1 else { fatalError("should be invalidated") }
             defer { fires += 1 }
             


### PR DESCRIPTION
@radex 

Fixes https://github.com/radex/SwiftyTimer/issues/27

Most of the migration was done using Xcode's migration tool. It is mostly about renaming `NSTimer` to `Timer`.

Minor thing to note: Swift 3 will now produce a warning of the result of `Timer.<method>` is unused.

Let me know if you have any question.