### PR TITLE
Fix pod install by specifying Swift verison in podfile

### DIFF
--- a/SwiftyTimer.podspec
+++ b/SwiftyTimer.podspec
@@ -14,4 +14,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
 
   s.source_files = 'Sources/*.swift'
+
+  s.swift_version = '3.0'
 end


### PR DESCRIPTION
This could help users to actually use the library, until you are able to merge the updates to swift 4.2